### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/People-Places-Solutions/GHAS-training-juice-shop/security/code-scanning/54](https://github.com/People-Places-Solutions/GHAS-training-juice-shop/security/code-scanning/54)

To fix this problem, we should avoid using the `$where` operator with user input entirely. Instead, we should use a standard query object to safely query the `orderId` field. This means replacing the `$where` clause with a direct query, such as `{ orderId: id }`, which does not evaluate any JavaScript and is safe from code injection. The change should be made in the `trackOrder` function in `routes/trackOrder.ts`, specifically on line 18. No additional imports or methods are required, as this is a standard MongoDB query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
